### PR TITLE
Adds indicators for started and finished requests

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
         grafana_version: ${GRAFANA_VERSION:-10.0.3}
     environment:
       GF_INSTALL_PLUGINS: https://storage.googleapis.com/grafana-llm-app/grafana-llm-app-0.1.0.zip; grafana-llm-app
-      OPENAI_API_KEY: $OPENAI_API_KEY
+      OPENAI_API_KEY: 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
     ports:
       - 3000:3000/tcp
     volumes:

--- a/src/pages/ExamplePage.tsx
+++ b/src/pages/ExamplePage.tsx
@@ -15,7 +15,7 @@ export function ExamplePage() {
   const [reply, setReply] = useState('');
 
   const [started, setStarted] = useState(false);
-  const [finished, setFinished] = useState(false)
+  const [finished, setFinished] = useState(true);
 
   const { loading, error, value } = useAsync(async () => {
     // Check if the LLM plugin is enabled and configured.


### PR DESCRIPTION
Request is pending if started and !finished

If there is a cleaner way to accomplish this we should do that instead as an example; also, have rxjs as a hard requirement feels perhaps not ideal, prior to this change rxjs was not required to simply call the 'llms' module of @grafana/experimental