### PR TITLE
Add vector search example

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,10 +8,18 @@ services:
       args:
         grafana_version: ${GRAFANA_VERSION:-10.0.3}
     environment:
-      GF_INSTALL_PLUGINS: https://storage.googleapis.com/grafana-llm-app/grafana-llm-app-0.1.0.zip; grafana-llm-app
+      GF_INSTALL_PLUGINS: grafana-llm-app
       OPENAI_API_KEY: $OPENAI_API_KEY
     ports:
       - 3000:3000/tcp
     volumes:
       - ./dist:/var/lib/grafana/plugins/grafana-llmexamples-app
       - ./provisioning:/etc/grafana/provisioning
+
+  qdrant:
+    image: qdrant/qdrant
+    volumes:
+      - qdrant-storage:/qdrant/storage
+
+volumes:
+  qdrant-storage:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@emotion/css": "^11.1.3",
         "@grafana/data": "^10.0.0",
-        "@grafana/experimental": "1.7.0",
+        "@grafana/experimental": "1.7.2",
         "@grafana/runtime": "^10.0.0",
         "@grafana/ui": "^10.0.0",
         "react": "17.0.2",
@@ -2639,9 +2639,9 @@
       }
     },
     "node_modules/@grafana/experimental": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@grafana/experimental/-/experimental-1.7.0.tgz",
-      "integrity": "sha512-3DfDzGTUnvG/v2U0lhBaB05j4x0bczrgylrg5Co6LMyRYh1kPA4XnK0dTshSxA6igjKqAjSacfwZQ40f4rLdqw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@grafana/experimental/-/experimental-1.7.2.tgz",
+      "integrity": "sha512-QliMmV26HXBBtVePHnPu6KaAa7oZtqF13jPmkYtrk6ZsbytuW4kfkSx+sA2oA2iWXvZ30JI4Q/fuPZ44W9cV1w==",
       "dependencies": {
         "@types/uuid": "^8.3.3",
         "uuid": "^8.3.2"
@@ -21459,9 +21459,9 @@
       }
     },
     "@grafana/experimental": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@grafana/experimental/-/experimental-1.7.0.tgz",
-      "integrity": "sha512-3DfDzGTUnvG/v2U0lhBaB05j4x0bczrgylrg5Co6LMyRYh1kPA4XnK0dTshSxA6igjKqAjSacfwZQ40f4rLdqw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@grafana/experimental/-/experimental-1.7.2.tgz",
+      "integrity": "sha512-QliMmV26HXBBtVePHnPu6KaAa7oZtqF13jPmkYtrk6ZsbytuW4kfkSx+sA2oA2iWXvZ30JI4Q/fuPZ44W9cV1w==",
       "requires": {
         "@types/uuid": "^8.3.3",
         "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@emotion/css": "^11.1.3",
     "@grafana/data": "^10.0.0",
-    "@grafana/experimental": "1.7.0",
+    "@grafana/experimental": "1.7.2",
     "@grafana/runtime": "^10.0.0",
     "@grafana/ui": "^10.0.0",
     "react": "17.0.2",

--- a/provisioning/plugins/apps.yaml
+++ b/provisioning/plugins/apps.yaml
@@ -6,7 +6,17 @@ apps:
   - type: 'grafana-llm-app'
     disabled: false
     jsonData:
-      openAIUrl: https://api.openai.com
-      openAIOrganizationID: $OPENAI_ORGANIZATION_ID
+      openai:
+        organizationId: $OPENAI_ORGANIZATION_ID
+      vector:
+        enabled: true
+        model: text-embedding-ada-002
+        embed:
+          type: openai
+        store:
+          type: qdrant
+          qdrant:
+            address: qdrant:6334
+
     secureJsonData:
       openAIKey: $OPENAI_API_KEY

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+
 import { AppRootProps } from '@grafana/data';
-import { ExamplePage } from '../../pages';
+
+import { ExamplePage, VectorSearch } from '../../pages';
 
 export function App(props: AppRootProps) {
-  return <ExamplePage />;
+  return (
+    <Switch>
+      <Route exact component={VectorSearch} path="/a/grafana-llmexamples-app/vector-search" />
+      {/* Default page */}
+      <Route component={ExamplePage} />
+    </Switch>
+  );
 }

--- a/src/pages/VectorSearch.tsx
+++ b/src/pages/VectorSearch.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from "react";
+import { useAsync } from 'react-use';
+
+import { llms } from '@grafana/experimental';
+import { PluginPage } from "@grafana/runtime";
+import { Button, Input, Spinner } from "@grafana/ui";
+
+const dashboardsCollection = 'grafana.core.dashboards';
+
+interface DashboardSearchResult {
+  title: string | null;
+  description: string | null;
+  panels: Array<{ title: string | null; description: string | null; }>;
+}
+
+export function VectorSearch(): JSX.Element {
+  // The current input value.
+  const [input, setInput] = useState('');
+  // The final search term to send to the vector service, updated when the button is clicked.
+  const [searchTerm, setSearchTerm] = useState('');
+  // The results from the vector service.
+  const [searchResults, setSearchResults] = useState<DashboardSearchResult[] | undefined>(undefined);
+
+  const { loading, error, value } = useAsync(async () => {
+    const value = {
+      enabled: await llms.vector.enabled(),
+    };
+    if (!value.enabled) {
+      return value;
+    }
+    if (searchTerm === '') {
+      return value;
+    }
+
+    const results = await llms.vector.search<DashboardSearchResult>({
+      query: searchTerm,
+      collection: dashboardsCollection,
+      topK: 5,
+    });
+    setSearchResults(results.map((result) => result.payload));
+    return value;
+  }, [searchTerm]);
+
+  return (
+    <PluginPage>
+      {value?.enabled ? (
+        <>
+          <h3>Semantic search for dashboards</h3>
+          <Input
+            value={input}
+            onChange={(e) => setInput(e.currentTarget.value)}
+            placeholder="Enter a search term"
+          />
+          <br />
+          <Button type="submit" onClick={() => setSearchTerm(input)}>Submit</Button>
+          <br />
+          <div>{loading ? (
+            <Spinner />
+          ) : (error ? (
+            <div>error: {error}</div>
+          ) : (searchResults === undefined ? (
+            <></>
+          ) : (
+            <>
+              <h4>Results</h4>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Title</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {searchResults?.map((result, i) => (
+                    <tr key={i}>
+                      <td>{result.title}</td>
+                      <td>{result.description}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </>
+          )))
+
+          }</div>
+        </>
+      ) : (
+        <div>Vector search not enabled.</div>
+      )}
+    </PluginPage>
+  )
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,1 +1,2 @@
 export { ExamplePage } from './ExamplePage';
+export { VectorSearch } from './VectorSearch';

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -27,6 +27,13 @@
       "path": "/a/grafana-llmexamples-app",
       "addToNav": true,
       "defaultNav": true
+    },
+    {
+      "type": "page",
+      "name": "Vector search",
+      "path": "/a/grafana-llmexamples-app/vector-search",
+      "addToNav": true,
+      "defaultNav": false
     }
   ],
   "dependencies": {


### PR DESCRIPTION
This PR adds a second page demonstrating how to use the vector search
API of the LLM app via @grafana/experimental.

Perhaps it would be good to show an example of few-shot learning too?
This is a start, though.

TODO before merge:

- [x] release new version of LLM app
- [x] release new version of @grafana/experimental
