### PR TITLE
Plugin.json: update with extensions info

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -42,5 +42,12 @@
   "dependencies": {
     "grafanaDependency": ">=9.5.2",
     "plugins": []
-  }
+  },
+  "extensions": [
+    {
+      "extensionPointId": "grafana/dashboard/panel/menu",
+      "title": "Explain this panel",
+      "type": "link"
+    }
+  ]
 }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
   "name": "LLM Examples",
   "id": "grafana-llmexamples-app",


### PR DESCRIPTION
### What changed?

- Manually added ui-extensions metadata to the plugin.json (to be able to lazy-load plugins in Grafana, based on [this PR](https://github.com/grafana/grafana/pull/88288)
- Updated the reference to the plugin.json schema (it was pointing to the old one)